### PR TITLE
Add streaming support to AgentTool

### DIFF
--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -355,9 +355,11 @@ async def _process_function_live_helper(
       function_response = {
           'status': f'No active streaming function named {function_name} found'
       }
-  elif hasattr(tool, 'func') and inspect.isasyncgenfunction(tool.func):
+  elif (
+      hasattr(tool, 'func') and inspect.isasyncgenfunction(tool.func)
+  ) or hasattr(tool, '_call_live'):
     # for streaming tool use case
-    # we require the function to be a async generator function
+    # function tools use async generators, agent tools implement _call_live
     async def run_tool_and_update_queue(tool, function_args, tool_context):
       try:
         async for result in __call_tool_live(

--- a/src/google/adk/tools/agent_tool.py
+++ b/src/google/adk/tools/agent_tool.py
@@ -22,6 +22,8 @@ from pydantic import model_validator
 from typing_extensions import override
 
 from . import _automatic_function_calling_util
+from ..agents.run_config import RunConfig
+from ..agents.run_config import StreamingMode
 from ..memory.in_memory_memory_service import InMemoryMemoryService
 from ..runners import Runner
 from ..sessions.in_memory_session_service import InMemorySessionService
@@ -125,7 +127,10 @@ class AgentTool(BaseTool):
 
     last_event = None
     async for event in runner.run_async(
-        user_id=session.user_id, session_id=session.id, new_message=content
+        user_id=session.user_id,
+        session_id=session.id,
+        new_message=content,
+        run_config=RunConfig(streaming_mode=StreamingMode.SSE),
     ):
       # Forward state delta to parent session.
       if event.actions.state_delta:
@@ -142,3 +147,58 @@ class AgentTool(BaseTool):
     else:
       tool_result = merged_text
     return tool_result
+
+  async def _call_live(
+      self,
+      *,
+      args: dict[str, Any],
+      tool_context: ToolContext,
+      invocation_context,
+  ):
+    """Streams results from the wrapped agent."""
+    from ..agents.llm_agent import LlmAgent
+
+    if self.skip_summarization:
+      tool_context.actions.skip_summarization = True
+
+    if isinstance(self.agent, LlmAgent) and self.agent.input_schema:
+      input_value = self.agent.input_schema.model_validate(args)
+      content = types.Content(
+          role='user',
+          parts=[
+              types.Part.from_text(
+                  text=input_value.model_dump_json(exclude_none=True)
+              )
+          ],
+      )
+    else:
+      content = types.Content(
+          role='user',
+          parts=[types.Part.from_text(text=args['request'])],
+      )
+
+    runner = Runner(
+        app_name=self.agent.name,
+        agent=self.agent,
+        artifact_service=ForwardingArtifactService(tool_context),
+        session_service=InMemorySessionService(),
+        memory_service=InMemoryMemoryService(),
+    )
+
+    session = await runner.session_service.create_session(
+        app_name=self.agent.name,
+        user_id='tmp_user',
+        state=tool_context.state.to_dict(),
+    )
+
+    async for event in runner.run_async(
+        user_id=session.user_id,
+        session_id=session.id,
+        new_message=content,
+        run_config=RunConfig(streaming_mode=StreamingMode.SSE),
+    ):
+      if event.actions.state_delta:
+        tool_context.state.update(event.actions.state_delta)
+      if not event.content or not event.content.parts:
+        continue
+      yield '\n'.join(p.text for p in event.content.parts if p.text)

--- a/tests/unittests/tools/test_agent_tool.py
+++ b/tests/unittests/tools/test_agent_tool.py
@@ -16,6 +16,8 @@ from google.adk.agents import Agent
 from google.adk.agents import SequentialAgent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.tools.agent_tool import AgentTool
+from google.adk.tools.tool_context import ToolContext
+from google.adk.events.event_actions import EventActions
 from google.genai.types import Part
 from pydantic import BaseModel
 from pytest import mark
@@ -209,3 +211,27 @@ def test_custom_schema():
   # The second request is the tool agent request.
   assert mock_model.requests[1].config.response_schema == CustomOutput
   assert mock_model.requests[1].config.response_mime_type == 'application/json'
+
+
+@mark.asyncio
+async def test_agent_tool_call_live():
+  mock_model = testing_utils.MockModel.create(['chunk1', 'chunk2'])
+
+  tool_agent = Agent(name='tool_agent', model=mock_model)
+  root_agent = Agent(name='root_agent', model=mock_model)
+
+  invocation_context = await testing_utils.create_invocation_context(root_agent)
+  tool_context = ToolContext(
+      invocation_context=invocation_context, event_actions=EventActions()
+  )
+
+  agent_tool = AgentTool(agent=tool_agent)
+  results = []
+  async for result in agent_tool._call_live(
+      args={'request': 'hi'},
+      tool_context=tool_context,
+      invocation_context=invocation_context,
+  ):
+    results.append(result)
+
+  assert results == ['chunk1']


### PR DESCRIPTION
## Summary
- enable AgentTool streaming via `_call_live`
- detect streaming tools in `functions.py`
- test streaming behavior for AgentTool

## Testing
- `PYTHONPATH=$PWD/src pytest tests/unittests/tools/test_agent_tool.py -k test_agent_tool_call_live -q`

------
https://chatgpt.com/codex/tasks/task_e_68683f82444c832786ff69a56c704272